### PR TITLE
Add Jest setup and helper tests

### DIFF
--- a/backend/jest.config.js
+++ b/backend/jest.config.js
@@ -1,0 +1,3 @@
+export default {
+  testEnvironment: 'node'
+};

--- a/backend/package.json
+++ b/backend/package.json
@@ -7,7 +7,8 @@
     "dev": "nodemon ./server.js --ignore __tests__",
     "debug": "node --inspect-brk -r sucrase/register src/server.js",
     "build": "sucrase ./src -d ./dist --transforms imports",
-    "start": "node ./dist/server.js"
+    "start": "node ./dist/server.js",
+    "test": "jest"
   },
   "keywords": [],
   "author": "",
@@ -26,5 +27,8 @@
     "typeorm": "^0.3.7",
     "vue": "^3.2.37",
     "youch": "^3.2.0"
+  },
+  "devDependencies": {
+    "jest": "^29.7.0"
   }
 }

--- a/backend/tests/helper.test.js
+++ b/backend/tests/helper.test.js
@@ -1,0 +1,28 @@
+import helper from '../src/app/config/helper.js';
+
+describe('helper', () => {
+  describe('getOffset', () => {
+    test('returns 0 for page 1 with size 10', () => {
+      expect(helper.getOffset(1, 10)).toBe(0);
+    });
+
+    test('returns correct offset for arbitrary page and size', () => {
+      expect(helper.getOffset(3, 5)).toBe(10);
+    });
+  });
+
+  describe('emptyOrRows', () => {
+    test('returns empty array when given null', () => {
+      expect(helper.emptyOrRows(null)).toEqual([]);
+    });
+
+    test('returns empty array when given undefined', () => {
+      expect(helper.emptyOrRows(undefined)).toEqual([]);
+    });
+
+    test('returns rows when array provided', () => {
+      const rows = [1, 2, 3];
+      expect(helper.emptyOrRows(rows)).toBe(rows);
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- add Jest as a dev dependency and `test` script
- create `jest.config.js`
- write tests for helper functions

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6843dccd0cb48325a56659c544ad73a7