### PR TITLE
Fix server port setup

### DIFF
--- a/backend/server.js
+++ b/backend/server.js
@@ -1,5 +1,7 @@
 import app from './app.js';
 
-app.listen(process.env.PORT || 3333, () => {
-  console.log(`Server is onlinne on localhost:${process.env.PORT}`);
+const port = process.env.PORT || 3333;
+
+app.listen(port, () => {
+  console.log(`Server is online on localhost:${port}`);
 });


### PR DESCRIPTION
## Summary
- set up port variable in server.js
- use the port variable in `app.listen` and log message
- fix small typo in log message

## Testing
- `npm test` *(fails: missing script)*
- `npm run build` *(fails: sucrase not found)*

------
https://chatgpt.com/codex/tasks/task_e_6843dcc74984832589b318b5d49d0b1d